### PR TITLE
Trivy bump

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -209,6 +209,10 @@
                                 <googleJavaFormat>
                                     <version>1.26.0</version>
                                 </googleJavaFormat>
+                                <importOrder>
+                                    <order>java|javax|dev|com|org|lombok</order>
+                                </importOrder>
+                                <removeUnusedImports />
                             </java>
                         </configuration>
                     </plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,7 @@
 
     <groupId>dev.vality</groupId>
     <artifactId>service-parent-pom</artifactId>
-    <version>3.0.9</version>
+    <version>3.0.10</version>
     <packaging>pom</packaging>
 
     <name>Vality parent</name>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>3.4.3</version>
+        <version>3.4.5</version>
     </parent>
 
     <groupId>dev.vality</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -49,16 +49,11 @@
         <pubSnapRepo>https://s01.oss.sonatype.org/content/repositories/snapshots</pubSnapRepo>
         <pubStagingRepoId>ossrh</pubStagingRepoId>
         <pubStagingRepo>https://s01.oss.sonatype.org/</pubStagingRepo>
-        <checkstyle.config.path>
-            https://raw.githubusercontent.com/valitydev/java-checkstyle-config/master/conf/valitydev_google_checkstyle.xml
-        </checkstyle.config.path>
-        <checkstyle.config.suppressions.path>
-            https://raw.githubusercontent.com/valitydev/java-checkstyle-config/master/conf/checkstyle-suppressions.xml
-        </checkstyle.config.suppressions.path>
         <dockerfile.base.service.tag>c0612d6052ac049496b72a23a04acb142035f249</dockerfile.base.service.tag>
         <shared-resources.version>3.0.0</shared-resources.version>
         <woody.version>2.0.9</woody.version>
         <resource.delimiter>${*}</resource.delimiter>
+        <spotless.skip>false</spotless.skip>
     </properties>
 
     <dependencyManagement>
@@ -196,6 +191,28 @@
             <build>
                 <plugins>
                     <plugin>
+                        <groupId>com.diffplug.spotless</groupId>
+                        <artifactId>spotless-maven-plugin</artifactId>
+                        <version>2.44.4</version>
+                        <executions>
+                            <execution>
+                                <id>spotless-check</id>
+                                <phase>validate</phase>
+                                <goals>
+                                    <goal>check</goal>
+                                </goals>
+                            </execution>
+                        </executions>
+                        <configuration>
+                            <skip>${spotless.skip}</skip>
+                            <java>
+                                <googleJavaFormat>
+                                    <version>1.26.0</version>
+                                </googleJavaFormat>
+                            </java>
+                        </configuration>
+                    </plugin>
+                    <plugin>
                         <groupId>org.springframework.boot</groupId>
                         <artifactId>spring-boot-maven-plugin</artifactId>
                         <executions>
@@ -226,38 +243,6 @@
                             <generateGitPropertiesFile>false</generateGitPropertiesFile>
                             <offline>true</offline>
                         </configuration>
-                    </plugin>
-                    <plugin>
-                        <groupId>org.apache.maven.plugins</groupId>
-                        <artifactId>maven-checkstyle-plugin</artifactId>
-                        <version>3.6.0</version>
-                        <dependencies>
-                            <dependency>
-                                <groupId>com.puppycrawl.tools</groupId>
-                                <artifactId>checkstyle</artifactId>
-                                <version>10.23.1</version>
-                            </dependency>
-                        </dependencies>
-                        <executions>
-                            <execution>
-                                <id>validate</id>
-                                <phase>validate</phase>
-                                <configuration>
-                                    <configLocation>${checkstyle.config.path}</configLocation>
-                                    <failsOnError>true</failsOnError>
-                                    <consoleOutput>true</consoleOutput>
-                                    <violationSeverity>warning</violationSeverity>
-                                    <sourceDirectories>
-                                        <sourceDirectory>${project.build.sourceDirectory}</sourceDirectory>
-                                    </sourceDirectories>
-                                    <includeTestSourceDirectory>true</includeTestSourceDirectory>
-                                    <suppressionsLocation>${checkstyle.config.suppressions.path}</suppressionsLocation>
-                                </configuration>
-                                <goals>
-                                    <goal>check</goal>
-                                </goals>
-                            </execution>
-                        </executions>
                     </plugin>
                     <plugin>
                         <groupId>org.jacoco</groupId>


### PR DESCRIPTION
мне не нравится функционал чекстайла который вынуждает вручную править файлы
и нравится как применяется ktlint
поэтому переходим на схожий плагин [spotless] и для джавы

я его инициализировал гугловским googleJavaFormat потому что гугл это база. но он специфичный и вместо 4 отступов делает 2 . типа так гугл считает правильным и это у них зашито, поэтому предлагаю выбрать между вариантами какой больше нравится 
можно следующими:
- googleJavaFormat
- eclipse
- palantirJavaFormat (форк googleJavaFormat с 4 отступами, самый близкий к нашему и меньше гит дифов предвидется )
- prettier


ниже с комментами как это выглядит 

